### PR TITLE
生存掉落物+配方，简中语言文件更新

### DIFF
--- a/src/main/resources/assets/vs_thermodynamics/lang/zh_cn.json
+++ b/src/main/resources/assets/vs_thermodynamics/lang/zh_cn.json
@@ -1,12 +1,12 @@
 {
   "create.gui.goggles.vs_thermodynamics.value": "当前的转速百分比",
-  "itemGroup.vs_thermodynamics_creative_tab": "瓦尔基里:热力学",
+  "itemGroup.vs_thermodynamics_creative_tab": "瓦尔基里：热力学",
 
-  "block.vs_thermodynamics.burner": "煤气炉",
-  "vs_thermodynamics.ponder.burner_usage.header": "煤气炉的使用",
+  "block.vs_thermodynamics.burner": "燃烧炉",
+  "vs_thermodynamics.ponder.burner_usage.header": "燃烧炉的使用",
   "vs_thermodynamics.ponder.burner_usage.text_1": "燃烧炉本身不会存储燃料",
   "vs_thermodynamics.ponder.burner_usage.text_2": "燃烧炉得到燃料供给同时打开阀门",
-  "vs_thermodynamics.ponder.burner_usage.text_3": "燃烧炉会填充上方的可以含水位置的体积,根据1w/1block的升力",
+  "vs_thermodynamics.ponder.burner_usage.text_3": "燃烧炉会填充上方的可以含水位置的体积,根据1w/1block来提供升力",
   "vs_thermodynamics.ponder.burner_usage.text_4": "根据虚拟热空气方块填充的位置会从热空气中心产生升力",
   "item.vs_thermodynamics.debug_stick": "调试棒",
   "item.vs_thermodynamics.link_stick": "链接棒"

--- a/src/main/resources/assets/vs_thermodynamics/lang/zh_cn.json
+++ b/src/main/resources/assets/vs_thermodynamics/lang/zh_cn.json
@@ -2,11 +2,11 @@
   "create.gui.goggles.vs_thermodynamics.value": "当前的转速百分比",
   "itemGroup.vs_thermodynamics_creative_tab": "瓦尔基里：热力学",
 
-  "block.vs_thermodynamics.burner": "燃烧炉",
-  "vs_thermodynamics.ponder.burner_usage.header": "燃烧炉的使用",
-  "vs_thermodynamics.ponder.burner_usage.text_1": "燃烧炉本身不会存储燃料",
-  "vs_thermodynamics.ponder.burner_usage.text_2": "燃烧炉得到燃料供给同时打开阀门",
-  "vs_thermodynamics.ponder.burner_usage.text_3": "燃烧炉会填充上方的可以含水位置的体积,根据1w/1block来提供升力",
+  "block.vs_thermodynamics.burner": "燃气炉",
+  "vs_thermodynamics.ponder.burner_usage.header": "燃气炉的使用",
+  "vs_thermodynamics.ponder.burner_usage.text_1": "燃气炉本身不会存储燃料",
+  "vs_thermodynamics.ponder.burner_usage.text_2": "燃气炉得到燃料供给同时打开阀门",
+  "vs_thermodynamics.ponder.burner_usage.text_3": "燃气炉会填充上方的可以含水位置的体积,根据1w/1block来提供升力",
   "vs_thermodynamics.ponder.burner_usage.text_4": "根据虚拟热空气方块填充的位置会从热空气中心产生升力",
   "item.vs_thermodynamics.debug_stick": "调试棒",
   "item.vs_thermodynamics.link_stick": "链接棒"

--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,5 @@
+{
+ "values": [
+   "vs_thermodynamics:burner"
+ ]
+}

--- a/src/main/resources/data/vs_thermodynamics/loot_tables/blocks/burner.json
+++ b/src/main/resources/data/vs_thermodynamics/loot_tables/blocks/burner.json
@@ -1,0 +1,20 @@
+{
+ "type": "minecraft:block",
+ "pools": [
+   {
+     "name": "vs_thermodynamics:burner",
+     "rolls": 1,
+     "entries": [
+       {
+         "type": "minecraft:item",
+         "name": "vs_thermodynamics:burner"
+       }
+     ],
+     "conditions": [
+       {
+         "condition": "minecraft:survives_explosion"
+       }
+     ]
+   }
+ ]
+}

--- a/src/main/resources/data/vs_thermodynamics/recipes/crafting/burner.json
+++ b/src/main/resources/data/vs_thermodynamics/recipes/crafting/burner.json
@@ -1,0 +1,29 @@
+{
+ "type": "minecraft:crafting_shaped",
+ "pattern": [
+   " B ",
+   "ACS",
+   " E "
+ ],
+ "key": {
+   "B": {
+     "item": "#forge:ingots/brass"
+   },
+   "A": {
+     "item": "create:andesite_alloy"
+   },
+   "C": {
+     "item": "minecraft:compass"
+   },
+   "S": {
+     "item": "create:shaft"
+   },
+   "E": {
+     "item": "create:empty_blaze_burner"
+   }
+ },
+ "result": {
+   "item": "vs_thermodynamics:burner",
+   "count": 1
+ }
+}


### PR DESCRIPTION
burner统一改为“燃气炉”；
燃气炉配方：
<img width="215" height="218" alt="image" src="https://github.com/user-attachments/assets/1e51f368-52b6-4286-9389-ff9759539d8a" />
解决了 #1 
